### PR TITLE
Reduce redundant logs

### DIFF
--- a/isu12q/test/run_bench.sh
+++ b/isu12q/test/run_bench.sh
@@ -8,5 +8,5 @@ systemctl start nginx
 systemctl start blackauth
 systemctl start isuports
 
-curl --retry 180 --retry-delay 1 --retry-all-errors -k -H 'Host: admin.t.isucon.pw' -X POST https://127.0.0.1:443/initialize
+curl -s --retry 180 --retry-delay 3 --retry-all-errors -k -H 'Host: admin.t.isucon.pw' -X POST https://127.0.0.1:443/initialize
 BENCHWARMER_target_ip=127.0.0.1 /opt/bench/bench.sh


### PR DESCRIPTION
ベンチ前の疎通確認で無駄なログが出過ぎてたので修正。
また、リトライの回数がちょっとギリギリだったので retry-delay を増やして対応。